### PR TITLE
(GH-1) Allow for large package sizes

### DIFF
--- a/src/SimpleChocolateyServer/Web.config
+++ b/src/SimpleChocolateyServer/Web.config
@@ -19,9 +19,14 @@
       <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah"/>
       <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah"/>
     </httpModules>
-    <httpRuntime maxRequestLength="31457280"/>
+    <httpRuntime maxRequestLength="2147482548"/>
   </system.web>
   <system.webServer>
+    <security>
+      <requestFiltering>
+        <requestLimits maxAllowedContentLength="2147482548" />
+      </requestFiltering>
+    </security>
     <validation validateIntegratedModeConfiguration="false"/>
     <modules runAllManagedModulesForAllRequests="true">
       <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" preCondition="managedHandler"/>


### PR DESCRIPTION
- Set maxRequestLength to 2GB (2,147,482,548) based on 
  https://msdn.microsoft.com/en-us/library/e1f13641(v=vs.100).aspx
- Set maxAllowedContentLength to 2GB (2,147,482,548) based on
  https://msdn.microsoft.com/en-us/library/ms689462(v=vs.90).aspx